### PR TITLE
quotes fix

### DIFF
--- a/modules/gateways/fondy/fondy_cls.php
+++ b/modules/gateways/fondy/fondy_cls.php
@@ -20,7 +20,7 @@ class Fondy_Cls
 
         $str = $password;
         foreach ($data as $k => $v) {
-            $str .= self::SIGNATURE_SEPARATOR . $v;
+            $str .= self::SIGNATURE_SEPARATOR . htmlspecialchars_decode($v);
         }
 
         if ($encoded) {


### PR DESCRIPTION
The result of the API returns "additional_info" with encoded double quotes.